### PR TITLE
自动更新 `latest.json` 缺失

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,84 @@ permissions:
   contents: write
 
 jobs:
+  prepare_release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.ensure_release.outputs.release_id }}
+    steps:
+      - name: Ensure single published release exists
+        id: ensure_release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = context.ref.replace("refs/tags/", "");
+            if (!tag || !tag.startsWith("v")) {
+              core.setFailed(`This workflow requires a tag ref, got: ${context.ref}`);
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const releaseName = `Cofree ${tag}`;
+            const releaseBody = `## Cofree ${tag}
+
+            ### 下载说明
+            - **macOS (Apple Silicon)**：下载 \`*_aarch64.dmg\`
+            - **macOS (Intel)**：下载 \`*_x64.dmg\`
+            - **Windows**：下载 \`.msi\` 或 \`-setup.exe\`
+
+            已安装用户可在应用内自动收到更新提示。
+
+            ### 安装说明
+            详见 [BUILD.md](https://github.com/J-York/Cofree/blob/main/docs/BUILD.md)`;
+
+            let release;
+            try {
+              const response = await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag: tag,
+              });
+              release = response.data;
+              core.info(`Found existing release ${release.id}`);
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              const created = await github.rest.repos.createRelease({
+                owner,
+                repo,
+                tag_name: tag,
+                name: releaseName,
+                body: releaseBody,
+                draft: false,
+                prerelease: false,
+              });
+              release = created.data;
+              core.info(`Created release ${release.id}`);
+            }
+
+            if (
+              release.draft ||
+              release.prerelease ||
+              release.name !== releaseName ||
+              (release.body ?? "") !== releaseBody
+            ) {
+              const updated = await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id: release.id,
+                name: releaseName,
+                body: releaseBody,
+                draft: false,
+                prerelease: false,
+              });
+              release = updated.data;
+              core.info(`Updated release ${release.id}`);
+            }
+
+            core.setOutput("release_id", String(release.id));
+
   release:
+    needs: prepare_release
     strategy:
       fail-fast: false
       matrix:
@@ -69,21 +146,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: 'Cofree ${{ github.ref_name }}'
-          releaseBody: |
-            ## Cofree ${{ github.ref_name }}
-            
-            ### 下载说明
-            - **macOS (Apple Silicon)**：下载 `*_aarch64.dmg`
-            - **macOS (Intel)**：下载 `*_x64.dmg`
-            - **Windows**：下载 `.msi` 或 `-setup.exe`
-            
-            已安装用户可在应用内自动收到更新提示。
-            
-            ### 安装说明
-            详见 [BUILD.md](https://github.com/J-York/Cofree/blob/main/docs/BUILD.md)
-          releaseDraft: true
-          prerelease: false
-          updaterJsonKeepUniversal: true
+          releaseId: ${{ needs.prepare_release.outputs.release_id }}
+          uploadUpdaterJson: true
+          uploadUpdaterSignatures: true
           args: --target ${{ matrix.platform.target }} --bundles ${{ matrix.platform.bundles }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cofree",
   "private": true,
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "cofree"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cofree"
-version = "0.0.5"
+version = "0.0.6"
 description = "Cofree desktop shell"
 authors = ["Cofree Team"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Cofree",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "identifier": "app.cofree.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",
@@ -30,6 +30,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": ["dmg", "app", "msi", "nsis"],
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix GitHub Actions release workflow to consolidate all artifacts into a single release and enable Tauri updater metadata generation (`latest.json`), bumping the version to v0.0.6.

The previous release workflow, especially with `releaseDraft: true` and concurrent matrix jobs, led to a race condition where `tauri-action` would create multiple draft releases for the same tag, splitting artifacts across them. This PR introduces a `prepare_release` job to pre-create a single release ID, which all subsequent matrix jobs then use for uploading, ensuring all artifacts are grouped correctly. Additionally, `latest.json` was not generated due to missing `createUpdaterArtifacts: true` in `tauri.conf.json`, which is now enabled.

---
<p><a href="https://cursor.com/agents/bc-2285a46c-1964-4059-8ff0-41784d12711b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2285a46c-1964-4059-8ff0-41784d12711b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.0.6 across all build artifacts
  * Enhanced release workflow with centralized release management and improved updater artifact handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->