### PR TITLE
软件终端依赖

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 /*
  * Cofree - AI Programming Cafe
  * Tauri 入口：presentation 层 commands 与 run()。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `windows_subsystem` attribute to prevent console window on Windows.

On Windows, Rust executables default to the `console` subsystem, which launches a terminal window alongside the GUI application. Closing this terminal terminates the application. Adding `#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]` ensures that release builds use the `windows` (GUI) subsystem, eliminating the console window and its associated termination behavior.

---
<p><a href="https://cursor.com/agents/bc-ce8f6f08-86f0-41b6-a308-ae2629872042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce8f6f08-86f0-41b6-a308-ae2629872042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows application no longer displays a console window in production builds, providing a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->