### PR TITLE
Windows 标题栏重复

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -34,7 +34,7 @@ use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 use futures_util::StreamExt;
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 use tracing::info;
 
 // ── Secure API Key 内存缓存 ──────────────────────────────────────────────────
@@ -1439,6 +1439,14 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .setup(|app| {
+            let window = app.get_webview_window("main")
+                .expect("main window not found");
+            #[cfg(not(target_os = "macos"))]
+            window.set_decorations(false)?;
+            window.show()?;
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             healthcheck,
             select_workspace_folder,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,6 +19,7 @@
         "minWidth": 960,
         "minHeight": 680,
         "resizable": true,
+        "visible": false,
         "decorations": true,
         "hiddenTitle": true,
         "titleBarStyle": "Overlay"

--- a/src/ui/components/WindowControls.tsx
+++ b/src/ui/components/WindowControls.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useEffect, useState } from "react";
+import { type ReactElement } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
 type Platform = "macos" | "windows" | "linux";
@@ -11,19 +11,8 @@ function detectPlatform(): Platform {
 }
 
 export function WindowControls(): ReactElement {
-  const [platform] = useState<Platform>(detectPlatform);
+  const platform = detectPlatform();
 
-  useEffect(() => {
-    // On Windows/Linux: programmatically disable system decorations
-    // so our custom buttons take over. On macOS this is handled by
-    // titleBarStyle: "Overlay" in tauri.conf.json which keeps the
-    // native traffic-light buttons.
-    if (platform !== "macos") {
-      void getCurrentWindow().setDecorations(false);
-    }
-  }, [platform]);
-
-  // macOS: native traffic lights are shown via titleBarStyle "Overlay"
   if (platform === "macos") return <></>;
 
   const win = getCurrentWindow();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Remove duplicate window control buttons on Windows by handling decoration removal in Rust's setup hook.

The previous setup caused a timing issue where the native Windows title bar briefly appeared alongside custom controls because `decorations: true` was set globally (for macOS traffic lights), but `setDecorations(false)` for Windows was only applied in a React `useEffect` after the window had already rendered with native decorations. This PR moves the decoration removal logic to the Rust `setup` hook, ensuring it's applied *before* the window is shown, thus preventing the double button issue and flicker.

---
<p><a href="https://cursor.com/agents/bc-005e74e7-8bdf-4031-adcf-c3bc6ea37925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-005e74e7-8bdf-4031-adcf-c3bc6ea37925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->