### PR TITLE
对话初始化

### DIFF
--- a/src/ui/pages/ChatPage.tsx
+++ b/src/ui/pages/ChatPage.tsx
@@ -1177,6 +1177,16 @@ export function ChatPage({ settings, isVisible, sidebarCollapsed, onToggleSideba
         setLiveContextTokens(first.lastTokenCount ?? null);
         setSessionNote("已切换工作区");
       }
+    } else if (wsPath) {
+      const newConversation = createConversation(wsPath, []);
+      setConversations(loadConversationList(wsPath));
+      setCurrentConversation(newConversation);
+      setActiveConversationIdState(newConversation.id);
+      setActiveConversationId(wsPath, newConversation.id);
+      setMessages([]);
+      messagesRef.current = [];
+      setLiveContextTokens(null);
+      setSessionNote("");
     } else {
       setCurrentConversation(null);
       setActiveConversationIdState(null);

--- a/src/ui/pages/ChatPage.tsx
+++ b/src/ui/pages/ChatPage.tsx
@@ -1068,6 +1068,37 @@ export function ChatPage({ settings, isVisible, sidebarCollapsed, onToggleSideba
     activeConversationIdRef.current = activeConversationId;
   }, [activeConversationId]);
 
+  // Recover from invalid/missing active conversation on startup.
+  // Without this, the first submit may clear input but not send.
+  useEffect(() => {
+    if (currentConversation || conversations.length === 0) {
+      return;
+    }
+
+    const preferredId =
+      activeConversationId &&
+      conversations.some((conversation) => conversation.id === activeConversationId)
+        ? activeConversationId
+        : conversations[0].id;
+    const recoveredConversation = loadConversation(wsPath, preferredId);
+    if (!recoveredConversation) {
+      return;
+    }
+
+    skipNextTimestampRef.current = true;
+    activeConversationIdRef.current = recoveredConversation.id;
+    setCurrentConversation(recoveredConversation);
+    setActiveConversationIdState(recoveredConversation.id);
+    setActiveConversationId(wsPath, recoveredConversation.id);
+    setMessages(recoveredConversation.messages);
+    messagesRef.current = recoveredConversation.messages;
+    setLiveContextTokens(recoveredConversation.lastTokenCount ?? null);
+    setSessionNote(recoveredConversation.messages.length ? "已恢复历史会话" : "");
+    setCategorizedError(null);
+    setLiveToolCalls([]);
+    setIsStreaming(false);
+  }, [wsPath, conversations, activeConversationId, currentConversation]);
+
   const handleCancel = (): void => {
     if (activeConversationId) {
       abortControllersRef.current.get(activeConversationId)?.abort();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the issue where the first message sent disappears without response by ensuring a conversation is always active or created.

The problem occurred when `currentConversation` was null, either because no active conversation was selected despite a list existing, or because there were no conversations at all (e.g., new workspace). The send logic would clear the input but not dispatch the message, as `currentConversation` was required. This PR adds logic to automatically select an existing conversation or create a new one to prevent this state.

---
<p><a href="https://cursor.com/agents/bc-6e3329d0-e04a-4157-accc-d559c889cf19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e3329d0-e04a-4157-accc-d559c889cf19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->