### PR TITLE
fix(orchestrator): prevent premature loop termination

### DIFF
--- a/src/orchestrator/planningLoop.ts
+++ b/src/orchestrator/planningLoop.ts
@@ -33,12 +33,10 @@ import {
   buildPatchPreflightRepairMessage,
   buildPseudoToolCallCompatibilityDiagnostic,
   buildPseudoToolCallRepairMessage,
-  buildReadOnlyTurnsWarningMessage,
   buildSameFileEditFailureMessage,
   buildSearchNotFoundRepairMessage,
   buildShellDialectRepairInstruction,
   buildToolNotFoundWarningMessage,
-  shouldForceReadOnlySummary,
   shouldRetryPseudoToolCall,
   shouldStopForConsecutiveFailures,
   shouldStopForToolNotFound,
@@ -90,7 +88,6 @@ import { resolveMatchedSnippets } from "./snippetMatching";
 import { assembleRuntimeContext, assembleSystemPrompt } from "../agents/promptAssembly";
 import type { ActionProposal } from "./types";
 
-const TOOL_LOOP_CHECKPOINT_TURNS = 50;
 const TOOL_LOOP_EFFICIENCY_WARNING_THRESHOLD = 40;
 const MAX_MULTI_ARTIFACT_REMINDER_ROUNDS = 2;
 const MAX_PROPOSED_ACTIONS_PER_BATCH = 5;
@@ -483,7 +480,6 @@ export async function runNativeToolCallingLoop(
   let searchNotFoundRepairRounds = 0;
   let pseudoToolCallRepairRounds = 0;
   const fileEditFailureTracker = new Map<string, number>();
-  let consecutiveReadOnlyTurns = 0;
   let toolChoiceOverride: "auto" | "none" | undefined;
   let lastWorkingMemoryFingerprint = "";
   const contextNotes = new ContextNoteBuffer();
@@ -544,20 +540,6 @@ export async function runNativeToolCallingLoop(
       console.warn(`[Loop] 达到绝对轮次上限 (${MAX_ABSOLUTE_TURNS})，强制终止`);
       return {
         assistantReply: `已达到工具调用轮次硬上限（${MAX_ABSOLUTE_TURNS} 轮），已自动终止。请检查任务复杂度或拆分为更小的子任务。`,
-        requestRecords,
-        proposedActions,
-        planState,
-        toolTrace,
-        assistantToolCalls: lastAssistantToolCalls,
-        loopMessages: captureLoopMessages(),
-        workingMemorySnapshot: currentWorkingMemorySnapshot(),
-      };
-    }
-
-    if (turn > 0 && turn % TOOL_LOOP_CHECKPOINT_TURNS === 0) {
-      console.log(`[Loop] 已运行 ${turn} 轮，到达检查点，暂停等待用户确认`);
-      return {
-        assistantReply: `已经持续调用了 ${turn} 轮工具，任务仍在进行中。如果需要继续，请回复「继续」。`,
         requestRecords,
         proposedActions,
         planState,
@@ -774,8 +756,28 @@ export async function runNativeToolCallingLoop(
       continue;
     }
 
+    if (
+      completion.finishReason === "length" &&
+      completion.toolCalls.length === 0 &&
+      completion.assistantMessage.content.trim()
+    ) {
+      console.warn(
+        `[Loop] Turn ${turn + 1}: 响应被 max_tokens 截断（仅有文本、无工具调用），不能作为最终回复，要求模型继续`,
+      );
+      contextNotes.push([
+        "系统提示：你的上一条文本回复在到达 max_tokens 时被截断，没有完整结束。",
+        "请基于已经写出的内容继续推进任务：要么直接发出下一个工具调用，要么用一两句话给出简洁的最终结论。",
+        "不要重复已经说过的内容，也不要再次输出长篇分析。",
+      ].join("\n"));
+      continue;
+    }
+
     if (completion.finishReason === "length" && completion.toolCalls.length > 0) {
       console.warn(`[Loop] Turn ${turn + 1}: 响应被截断但包含 ${completion.toolCalls.length} 个工具调用，继续处理已解析的调用`);
+      contextNotes.push([
+        "系统提示：上一轮回复因到达 max_tokens 被截断，最后一个工具调用的参数可能不完整。",
+        "执行结果如有异常，请缩小调用范围（例如分多次小补丁）后重试，避免单次工具参数过大。",
+      ].join("\n"));
     }
 
     if (!completion.toolCalls.length) {
@@ -1140,20 +1142,6 @@ export async function runNativeToolCallingLoop(
         knownFilesList,
         "请基于已有信息继续推进任务，而非重复读取。如需特定代码片段，请用 start_line/end_line 精确读取。",
       ].join("\n"));
-    }
-
-    const turnHasPropose = completion.toolCalls.some((toolCall) => toolCall.function.name.startsWith("propose_"));
-    if (!turnHasPropose && turnSuccessCount > 0) {
-      consecutiveReadOnlyTurns += 1;
-    } else {
-      consecutiveReadOnlyTurns = 0;
-    }
-
-    if (shouldForceReadOnlySummary(consecutiveReadOnlyTurns)) {
-      console.log(`[Loop] 连续 ${consecutiveReadOnlyTurns} 轮纯读取，强制要求总结`);
-      contextNotes.push(buildReadOnlyTurnsWarningMessage(consecutiveReadOnlyTurns));
-      toolChoiceOverride = "none";
-      consecutiveReadOnlyTurns = 0;
     }
 
     if (turnHasToolNotFound) {

--- a/src/orchestrator/repairPolicies.ts
+++ b/src/orchestrator/repairPolicies.ts
@@ -8,7 +8,6 @@ export const MAX_SEARCH_NOT_FOUND_REPAIR_ROUNDS = 2;
 export const MAX_PSEUDO_TOOL_CALL_REPAIR_ROUNDS = 5;
 export const MAX_TOOL_NOT_FOUND_STRIKES = 3;
 export const MAX_CONSECUTIVE_FAILURE_TURNS = 5;
-export const MAX_CONSECUTIVE_READ_ONLY_TURNS = 8;
 export const MAX_SAME_FILE_EDIT_FAILURES = 4;
 
 const PATCH_REPAIR_INSTRUCTION =
@@ -34,10 +33,6 @@ export function shouldRetryPseudoToolCall(rounds: number): boolean {
   return rounds < MAX_PSEUDO_TOOL_CALL_REPAIR_ROUNDS;
 }
 
-export function shouldForceReadOnlySummary(consecutiveReadOnlyTurns: number): boolean {
-  return consecutiveReadOnlyTurns >= MAX_CONSECUTIVE_READ_ONLY_TURNS;
-}
-
 export function shouldStopForToolNotFound(toolNotFoundStrikes: number): boolean {
   return toolNotFoundStrikes >= MAX_TOOL_NOT_FOUND_STRIKES;
 }
@@ -60,10 +55,6 @@ export function buildPseudoToolCallRepairMessage(enabledToolNames: string[]): st
 
 export function buildPseudoToolCallCompatibilityDiagnostic(protocolLabel: string): string {
   return `当前模型在 ${protocolLabel} 协议下连续输出伪工具调用。已停止自动继续。建议换用工具调用更稳定的模型。`;
-}
-
-export function buildReadOnlyTurnsWarningMessage(consecutiveReadOnlyTurns: number): string {
-  return `系统警告：已连续 ${consecutiveReadOnlyTurns} 轮只读取文件。请立即基于已有信息给出回答或提出动作。`;
 }
 
 export function buildToolNotFoundWarningMessage(


### PR DESCRIPTION
## Summary

The agent was stopping mid-task in three different ways. This PR fixes the silent ones and removes the two heuristics that surprised users on legitimate work.

### Bug fixes

- **`finish_reason=length` with non-empty text but no tool_calls** was treated as the final answer at [planningLoop.ts:832](src/orchestrator/planningLoop.ts#L832), so a reply that ran out of tokens mid-sentence was returned to the user as if it were complete. Now caught one branch earlier — the loop re-prompts the model to continue from what was already written, without popping the truncated turn from history.
- **`finish_reason=length` with tool_calls** previously only logged a warning. The last tool call's JSON arguments may be truncated; the JSON-repair path closes brackets but the resulting call can have garbage args. Now also pushes a context note asking the model to shrink the next call (smaller patches, narrower reads) so the truncation does not recur.

### Removed guards

- **50-turn checkpoint pause** (`TOOL_LOOP_CHECKPOINT_TURNS = 50`) returned a "回复「继续」" message every 50 turns. Surprising on long exploration runs that the user expected to finish in one go.
- **8-turn read-only forced-summary** (`MAX_CONSECUTIVE_READ_ONLY_TURNS = 8`) flipped `toolChoice` to `"none"` after 8 consecutive read-only tool calls, prematurely forcing a summary on tasks like "explore this codebase and answer X." Removed.

What still terminates the loop:

- 150-turn hard cap (`MAX_ABSOLUTE_TURNS`) — only safety net for runaway loops
- Consecutive-failure breaker (5 turns of all-failed tools)
- Consecutive `tool_not_found` breaker (3 turns)
- LLM request error after 3 retries
- User abort signal
- Soft 40-turn efficiency note (does **not** terminate)

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 457/457 pass (incl. `does not force-stop exploration tasks after 25 tool turns`)
- [ ] Manual: run a multi-file exploration task and verify it no longer pauses at turn 50 or gets force-summarized at turn 8
- [ ] Manual: trigger a `max_tokens` truncation on a long final answer and verify the loop continues instead of returning a half sentence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted responses—the system now continues appropriately when responses are truncated mid-content, ensuring better continuity in multi-turn interactions.

* **Improvements**
  * Removed operational constraints that unnecessarily limited consecutive interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->