### PR TITLE
feat(security): harden shell cancel, bound job memory, persist audit log

### DIFF
--- a/src-tauri/src/application/workspace.rs
+++ b/src-tauri/src/application/workspace.rs
@@ -9,7 +9,7 @@ use crate::infrastructure::{
 };
 use glob::glob as glob_match;
 use regex::Regex;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
@@ -19,17 +19,89 @@ use std::sync::{
     Arc, Mutex,
 };
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, State};
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 #[derive(Default)]
 pub struct ShellJobStore {
     jobs: Arc<Mutex<HashMap<String, Arc<ShellJobHandle>>>>,
     /// Retains the final result of completed/cancelled jobs so that
     /// check_shell_job can still report exit_code / stdout / stderr after the
-    /// active entry is removed.  Entries are written just before removal from
-    /// `jobs` and kept until the store is dropped.
-    completed: Arc<Mutex<HashMap<String, CompletedJobResult>>>,
+    /// active entry is removed. Bounded by SHELL_COMPLETED_JOBS_MAX (FIFO) and
+    /// SHELL_COMPLETED_JOB_TTL_SECS (lazy TTL on read/write).
+    completed: Arc<Mutex<CompletedJobStore>>,
+}
+
+#[derive(Default)]
+struct CompletedJobStore {
+    map: HashMap<String, CompletedJobResult>,
+    /// Insertion-order queue used to evict the oldest entry when over capacity.
+    order: VecDeque<String>,
+}
+
+impl CompletedJobStore {
+    fn insert(&mut self, job_id: String, mut entry: CompletedJobResult) {
+        if entry.completed_at_secs == 0 {
+            entry.completed_at_secs = now_unix_secs();
+        }
+        self.evict_expired(entry.completed_at_secs);
+
+        if self.map.insert(job_id.clone(), entry).is_some() {
+            // Replacing an existing entry — drop the old position so it doesn't
+            // count twice toward the cap.
+            if let Some(pos) = self.order.iter().position(|id| id == &job_id) {
+                self.order.remove(pos);
+            }
+        }
+        self.order.push_back(job_id);
+
+        while self.order.len() > config::SHELL_COMPLETED_JOBS_MAX {
+            if let Some(oldest) = self.order.pop_front() {
+                self.map.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn get(&mut self, job_id: &str) -> Option<CompletedJobResult> {
+        let now = now_unix_secs();
+        self.evict_expired(now);
+        self.map.get(job_id).cloned()
+    }
+
+    fn evict_expired(&mut self, now: u64) {
+        let ttl = config::SHELL_COMPLETED_JOB_TTL_SECS;
+        if ttl == 0 {
+            return;
+        }
+        // Entries are appended in order, so the front is always the oldest.
+        // Pop until we hit one that is still alive.
+        while let Some(front) = self.order.front() {
+            let alive = self
+                .map
+                .get(front)
+                .map(|entry| now.saturating_sub(entry.completed_at_secs) < ttl)
+                .unwrap_or(false);
+            if alive {
+                break;
+            }
+            let stale = self.order.pop_front();
+            if let Some(stale_id) = stale {
+                self.map.remove(&stale_id);
+            }
+        }
+    }
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 struct ShellJobHandle {
@@ -46,6 +118,10 @@ pub struct CompletedJobResult {
     pub cancelled: bool,
     pub stdout: String,
     pub stderr: String,
+    /// Unix epoch seconds when the job finished. Set automatically by
+    /// CompletedJobStore::insert when zero.
+    #[serde(skip)]
+    pub completed_at_secs: u64,
 }
 
 struct ShellOutputCapture {
@@ -1187,6 +1263,7 @@ pub fn start_shell_command(
             cancelled,
             stdout: final_result.stdout,
             stderr: final_result.stderr,
+            completed_at_secs: now_unix_secs(),
         };
         if let Ok(mut guard) = completed_for_thread.lock() {
             guard.insert(job_id_for_thread.clone(), completed_entry);
@@ -1298,7 +1375,7 @@ pub fn cancel_shell_command(
         .lock()
         .map_err(|_| "shell job lock poisoned".to_string())?;
     if let Some(child) = child_guard.as_mut() {
-        child.kill().map_err(|e| format!("取消命令失败: {}", e))?;
+        terminate_child_tree(child);
         return Ok(true);
     }
 
@@ -1348,11 +1425,11 @@ pub fn check_shell_job(
 
     // Not in active registry — check the completed results store.
     let completed = {
-        let guard = jobs
+        let mut guard = jobs
             .completed
             .lock()
             .map_err(|_| "completed job store lock poisoned".to_string())?;
-        guard.get(&job_id_trimmed).cloned()
+        guard.get(&job_id_trimmed)
     };
 
     if let Some(result) = completed {
@@ -1378,7 +1455,8 @@ pub fn check_shell_job(
 }
 
 fn spawn_shell_child(workspace: &Path, shell_trimmed: &str) -> Result<Child, String> {
-    if cfg!(target_os = "windows") {
+    #[cfg(windows)]
+    {
         Command::new("powershell")
             .args(["-NoProfile", "-Command", shell_trimmed])
             .current_dir(workspace)
@@ -1391,8 +1469,11 @@ fn spawn_shell_child(workspace: &Path, shell_trimmed: &str) -> Result<Child, Str
             .env("CLICOLOR", "0")
             .spawn()
             .map_err(|e| format!("启动 powershell 失败: {}", e))
-    } else {
-        Command::new("sh")
+    }
+    #[cfg(unix)]
+    {
+        let mut command = Command::new("sh");
+        command
             .args(["-c", shell_trimmed])
             .current_dir(workspace)
             .stdin(Stdio::null())
@@ -1402,10 +1483,51 @@ fn spawn_shell_child(workspace: &Path, shell_trimmed: &str) -> Result<Child, Str
             .env("DEBIAN_FRONTEND", "noninteractive")
             .env("GIT_TERMINAL_PROMPT", "0")
             .env("PAGER", "cat")
-            .env("CLICOLOR", "0")
+            .env("CLICOLOR", "0");
+        // Put the child in a new process group whose PGID equals its PID, so
+        // cancel can signal the entire descendant tree via `kill -KILL -<pgid>`.
+        // Without this, child.kill() only reaches the immediate `sh` process and
+        // long-running grandchildren (node, vite, …) become orphans.
+        command.process_group(0);
+        command
             .spawn()
             .map_err(|e| format!("启动 sh 失败: {}", e))
     }
+}
+
+/// Best-effort recursive termination of a child process tree.
+///
+/// Unix: `kill -KILL -<pgid>` reaches every process spawned by the child since
+/// `spawn_shell_child` puts the child in its own process group.
+/// Windows: `taskkill /T /F /PID <pid>` walks the parent→child relationship
+/// recorded in the process snapshot and force-terminates each.
+///
+/// Always falls back to `child.kill()` so if the external tool is missing or
+/// fails for any reason the immediate child is still terminated.
+fn terminate_child_tree(child: &mut Child) {
+    let pid = child.id();
+
+    #[cfg(unix)]
+    {
+        // Negative PID signals the whole process group. SIGKILL because we
+        // already treat cancel as terminal — there's no chance for cleanup.
+        let _ = Command::new("kill")
+            .args(["-KILL", &format!("-{}", pid)])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+
+    #[cfg(windows)]
+    {
+        let _ = Command::new("taskkill")
+            .args(["/T", "/F", "/PID", &pid.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+
+    let _ = child.kill();
 }
 
 fn emit_shell_command_event(app: &AppHandle, event: ShellCommandEvent) {
@@ -1537,7 +1659,7 @@ fn collect_shell_command_result(
             Ok(None) => {
                 if timeout.is_some_and(|limit| started_at.elapsed() >= limit) {
                     timed_out = true;
-                    let _ = child.kill();
+                    terminate_child_tree(&mut child);
                     break child
                         .wait()
                         .map_err(|e| format!("终止超时命令失败: {}", e))?;
@@ -1641,7 +1763,7 @@ fn collect_shell_job_result(
                 Ok(None) => {
                     if timeout.is_some_and(|limit| started_at.elapsed() >= limit) {
                         timed_out = true;
-                        let _ = child.kill();
+                        terminate_child_tree(child);
                         Some(child.wait().map_err(|e| format!("终止超时命令失败: {}", e)))
                     } else {
                         None

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -143,8 +143,22 @@ pub fn append_action_audit_log(record_json: String) -> Result<(), String> {
     if let Ok(meta) = fs::metadata(&path) {
         if meta.len() > ACTION_AUDIT_LOG_MAX_BYTES {
             let backup = dir.join("audit.jsonl.1");
+            // remove_file failing with NotFound is the common case (no prior
+            // backup); other failures are not actionable here — rename below
+            // will fail with a clearer error if the path is still occupied.
             let _ = fs::remove_file(&backup);
-            let _ = fs::rename(&path, &backup);
+            // rename can legitimately fail (e.g., Windows holding the file
+            // handle from an external tail/viewer). When it does, we've
+            // already deleted the old backup, so emit a warning instead of
+            // letting the loss go silent. audit.jsonl itself is untouched.
+            if let Err(e) = fs::rename(&path, &backup) {
+                tracing::warn!(
+                    from = %path.display(),
+                    to = %backup.display(),
+                    error = %e,
+                    "audit log rotation: rename failed; previous backup is lost"
+                );
+            }
         }
     }
 

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -4,10 +4,22 @@ use crate::infrastructure::cofree_home_dir;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
+use std::sync::{Mutex, OnceLock};
 
 /// 审计日志在被滚动到 .1 备份前的最大字节数。
 /// 单条审计记录通常 < 4KB，10MB 大约可容纳几千条；用户可定期清理或导出。
 const ACTION_AUDIT_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Process-wide lock around the audit-log append flow. Tauri dispatches
+/// commands on a thread pool, so two `recordSensitiveActionAudit` calls can
+/// land in `append_action_audit_log` simultaneously. Without this lock the
+/// metadata-size check, rotation rename, and append-open would race against
+/// each other (TOCTOU on size, lost rotations when two threads both decide to
+/// rotate). Same pattern as `secure_store.rs` / `http.rs`.
+fn audit_log_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
 
 #[tauri::command]
 pub fn healthcheck() -> AppHealth {
@@ -113,6 +125,15 @@ pub fn append_action_audit_log(record_json: String) -> Result<(), String> {
         serde_json::to_string(&parsed).map_err(|e| format!("serialize audit record: {}", e))?;
 
     let dir = cofree_home_dir().map_err(|e| e.to_string())?;
+
+    // Serialize the size-check → rotate → open → write window across all
+    // concurrent Tauri command invocations in this process. Acquired only
+    // once we have valid input to log; cheap parsing/path resolution above
+    // stays outside the critical section.
+    let _guard = audit_log_lock()
+        .lock()
+        .map_err(|_| "audit log lock poisoned".to_string())?;
+
     fs::create_dir_all(&dir)
         .map_err(|e| format!("create cofree home dir failed: {}", e))?;
     let path = dir.join("audit.jsonl");
@@ -132,9 +153,15 @@ pub fn append_action_audit_log(record_json: String) -> Result<(), String> {
         .append(true)
         .open(&path)
         .map_err(|e| format!("open audit log failed: {}", e))?;
-    file.write_all(line.as_bytes())
-        .map_err(|e| format!("write audit log failed: {}", e))?;
-    file.write_all(b"\n")
+    // Single write_all for the JSON record + newline. Two separate writes
+    // can interleave with another writer's bytes when O_APPEND is used (each
+    // write() syscall atomically seeks-and-writes, but the boundary between
+    // two writes is a window for someone else's record to land), producing
+    // malformed JSONL. One buffer = one syscall for records ≤ PIPE_BUF (4 KB
+    // on Linux/macOS) which is well above our typical record size.
+    let mut buf = line.into_bytes();
+    buf.push(b'\n');
+    file.write_all(&buf)
         .map_err(|e| format!("write audit log failed: {}", e))?;
     Ok(())
 }

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -1,7 +1,13 @@
 use crate::application;
 use crate::domain::{AppError, AppHealth, RecoveryResult, WorkspaceInfo};
+use crate::infrastructure::cofree_home_dir;
 use std::fs;
+use std::io::Write;
 use std::path::Path;
+
+/// 审计日志在被滚动到 .1 备份前的最大字节数。
+/// 单条审计记录通常 < 4KB，10MB 大约可容纳几千条；用户可定期清理或导出。
+const ACTION_AUDIT_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
 
 #[tauri::command]
 pub fn healthcheck() -> AppHealth {
@@ -81,6 +87,56 @@ pub fn load_latest_workflow_checkpoint(session_id: String) -> Result<RecoveryRes
 #[tauri::command]
 pub fn delete_workflow_checkpoints(session_prefix: String) -> Result<u64, AppError> {
     application::delete_workflow_checkpoints(session_prefix)
+}
+
+/// Append a single audit record (JSON object, encoded as a string by the
+/// frontend) to `~/.cofree/audit.jsonl`. The frontend's localStorage cache is
+/// kept as a UI mirror but the file is the source of truth — it survives
+/// browser-data clears, app reinstalls, and the localStorage 200-record cap.
+///
+/// The record is parsed once for validation, then re-serialized on a single
+/// line so the file remains valid JSONL even if the caller passed pretty-
+/// printed input.
+///
+/// When the file exceeds `ACTION_AUDIT_LOG_MAX_BYTES` it is rotated to
+/// `audit.jsonl.1` (overwriting any prior backup) before the new line is
+/// appended. We keep only one rotation generation — callers concerned about
+/// long-term retention should export to JSON/CSV via the existing settings UI.
+#[tauri::command]
+pub fn append_action_audit_log(record_json: String) -> Result<(), String> {
+    let parsed: serde_json::Value = serde_json::from_str(&record_json)
+        .map_err(|e| format!("invalid audit record json: {}", e))?;
+    if !parsed.is_object() {
+        return Err("audit record must be a JSON object".to_string());
+    }
+    let line =
+        serde_json::to_string(&parsed).map_err(|e| format!("serialize audit record: {}", e))?;
+
+    let dir = cofree_home_dir().map_err(|e| e.to_string())?;
+    fs::create_dir_all(&dir)
+        .map_err(|e| format!("create cofree home dir failed: {}", e))?;
+    let path = dir.join("audit.jsonl");
+
+    // Rotate if oversized. We only keep one generation of backup; older
+    // history must be exported via the audit UI.
+    if let Ok(meta) = fs::metadata(&path) {
+        if meta.len() > ACTION_AUDIT_LOG_MAX_BYTES {
+            let backup = dir.join("audit.jsonl.1");
+            let _ = fs::remove_file(&backup);
+            let _ = fs::rename(&path, &backup);
+        }
+    }
+
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|e| format!("open audit log failed: {}", e))?;
+    file.write_all(line.as_bytes())
+        .map_err(|e| format!("write audit log failed: {}", e))?;
+    file.write_all(b"\n")
+        .map_err(|e| format!("write audit log failed: {}", e))?;
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,8 +11,9 @@ pub mod shell;
 pub mod snapshot;
 
 pub use app::{
-    delete_workflow_checkpoints, get_workspace_info, healthcheck, load_latest_workflow_checkpoint,
-    save_file_dialog, save_workflow_checkpoint, select_workspace_folder, validate_git_repo,
+    append_action_audit_log, delete_workflow_checkpoints, get_workspace_info, healthcheck,
+    load_latest_workflow_checkpoint, save_file_dialog, save_workflow_checkpoint,
+    select_workspace_folder, validate_git_repo,
 };
 pub use diagnostics::get_workspace_diagnostics;
 pub use fs::{

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -35,6 +35,11 @@ pub const SHELL_TIMEOUT_DEFAULT_MS: u64 = 120_000;
 pub const SHELL_TIMEOUT_MIN_MS: u64 = 1_000;
 pub const SHELL_TIMEOUT_MAX_MS: u64 = 600_000;
 
+/// 已完成 shell job 在内存中保留的最大条数（超过则按 FIFO 淘汰最旧条目）。
+pub const SHELL_COMPLETED_JOBS_MAX: usize = 200;
+/// 已完成 shell job 的存活时间（秒）。超过此时长的条目被惰性清除。
+pub const SHELL_COMPLETED_JOB_TTL_SECS: u64 = 24 * 60 * 60;
+
 /// HTTP fetch 默认最大 body 大小（字节）
 pub const FETCH_DEFAULT_MAX_BYTES: usize = 512 * 1024;
 

--- a/src-tauri/src/infrastructure/mod.rs
+++ b/src-tauri/src/infrastructure/mod.rs
@@ -7,5 +7,6 @@ pub use checkpoint_repo::{
     delete_checkpoints_by_session_prefix, load_latest_checkpoint, save_checkpoint,
 };
 pub use paths::{
-    canonicalize_workspace_root, generate_id, snapshots_root_dir, resolve_workspace_or_absolute_path,
+    canonicalize_workspace_root, cofree_home_dir, generate_id, resolve_workspace_or_absolute_path,
+    snapshots_root_dir,
 };

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14,14 +14,14 @@ mod secure_store;
 
 use crate::commands::ShellJobStore;
 use crate::commands::{
-    apply_workspace_patch, build_workspace_edit_patch, cancel_http_request, cancel_shell_command,
-    check_shell_job, check_workspace_patch,
-    create_workspace_snapshot, delete_secure_api_key, delete_skill_directory,
-    delete_snippet_file, delete_workflow_checkpoints, fetch_litellm_models, fetch_url,
-    get_home_dir, get_workspace_diagnostics, get_workspace_info, git_diff_workspace,
-    git_status_workspace, glob_workspace_files, grep_workspace_files, healthcheck,
-    install_skill_from_zip, list_workspace_files, load_latest_workflow_checkpoint, load_secure_api_key,
-    open_system_terminal, read_absolute_file, read_workspace_file, perform_http_request_stream,
+    append_action_audit_log, apply_workspace_patch, build_workspace_edit_patch, cancel_http_request,
+    cancel_shell_command, check_shell_job, check_workspace_patch, create_workspace_snapshot,
+    delete_secure_api_key, delete_skill_directory, delete_snippet_file,
+    delete_workflow_checkpoints, fetch_litellm_models, fetch_url, get_home_dir,
+    get_workspace_diagnostics, get_workspace_info, git_diff_workspace, git_status_workspace,
+    glob_workspace_files, grep_workspace_files, healthcheck, install_skill_from_zip,
+    list_workspace_files, load_latest_workflow_checkpoint, load_secure_api_key,
+    open_system_terminal, perform_http_request_stream, read_absolute_file, read_workspace_file,
     restore_workspace_snapshot, run_shell_command, save_file_dialog, save_secure_api_key,
     save_workflow_checkpoint, scan_workspace_structure, select_workspace_folder,
     start_shell_command, validate_git_repo, write_snippet_file,
@@ -93,7 +93,8 @@ pub fn run() {
             install_skill_from_zip,
             delete_skill_directory,
             write_snippet_file,
-            delete_snippet_file
+            delete_snippet_file,
+            append_action_audit_log
         ])
         .run(tauri::generate_context!())
         .expect("error while running cofree tauri application");

--- a/src/lib/auditLog.ts
+++ b/src/lib/auditLog.ts
@@ -14,7 +14,40 @@ import { redactSensitiveText, sanitizeForPersistence } from "./redaction";
 const AUDIT_LOG_STORAGE_KEY = "cofree.audit.llm.v1";
 const ACTION_AUDIT_LOG_STORAGE_KEY = "cofree.audit.actions.v1";
 const ERROR_AUDIT_LOG_STORAGE_KEY = "cofree.audit.errors.v1";
+/**
+ * Capacity of the in-localStorage UI cache. The on-disk JSONL file at
+ * ~/.cofree/audit.jsonl is the source of truth for sensitive-action history;
+ * localStorage just keeps recent rows around for fast UI rendering.
+ */
 const MAX_AUDIT_RECORDS = 200;
+
+function isTauriRuntime(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return "__TAURI_INTERNALS__" in window;
+}
+
+/**
+ * Best-effort append to the persistent audit log on disk. Failures are logged
+ * but never thrown — losing one row is preferable to breaking the action that
+ * triggered the audit. Only invoked inside Tauri; in browser dev mode the
+ * localStorage cache is the only sink.
+ */
+function appendActionAuditToDisk(record: SensitiveActionAuditRecord): void {
+  if (!isTauriRuntime()) {
+    return;
+  }
+  // Lazy import keeps the Tauri API out of test/jsdom bundles.
+  void import("@tauri-apps/api/core")
+    .then(({ invoke }) =>
+      invoke("append_action_audit_log", { recordJson: JSON.stringify(record) }),
+    )
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.warn("append_action_audit_log failed", error);
+    });
+}
 
 export interface LLMAuditRecord {
   requestId: string;
@@ -221,6 +254,13 @@ export function recordSensitiveActionAudit(record: SensitiveActionAuditRecord): 
     details: (sanitizeForPersistence(record.details) as Record<string, unknown>) ?? {}
   };
 
+  // 1. Persistent on-disk JSONL — survives clearing browser data, app
+  //    reinstalls, and the localStorage cache cap. This is the audit source
+  //    of truth.
+  appendActionAuditToDisk(safeRecord);
+
+  // 2. localStorage UI cache — keeps the last N rows for fast rendering of
+  //    the audit panel without hitting disk.
   const next = [safeRecord, ...readSensitiveActionAuditRecords()].slice(0, MAX_AUDIT_RECORDS);
   window.localStorage.setItem(ACTION_AUDIT_LOG_STORAGE_KEY, JSON.stringify({ records: next }));
 }


### PR DESCRIPTION
## Summary

Fixes the three medium-priority items from a recent shell-execution / approval audit:

- **Cancel now kills descendants, not just `sh`.** `spawn_shell_child` puts the child in its own process group on Unix (`Command::process_group(0)`); `terminate_child_tree` then signals the whole group via `kill -KILL -<pgid>`. On Windows we shell out to `taskkill /T /F /PID`. Wired into cancel + both timeout-kill paths. Previously `child.kill()` only hit the `sh`/`powershell` wrapper, so `npm run dev` → `node` style children leaked.
- **Completed-job snapshots are bounded.** `ShellJobStore.completed` becomes a tiny LRU + lazy TTL store (`SHELL_COMPLETED_JOBS_MAX=200`, `SHELL_COMPLETED_JOB_TTL_SECS=24h`). Long sessions no longer grow this map without limit. `CompletedJobResult` carries a `completed_at_secs` timestamp; `#[serde(skip)]` keeps the wire shape unchanged.
- **Audit log persists to `~/.cofree/audit.jsonl`.** New `append_action_audit_log` Tauri command writes one JSON line per `recordSensitiveActionAudit` call. The localStorage cache (cap 200) stays as a UI mirror; the file is now the source of truth and survives cache clears / reinstalls. Auto-rotates to `audit.jsonl.1` past 10 MB; write failures are logged, never thrown.

No new crate dependencies; the kill-tree path uses only `std::process::Command` + the `kill` / `taskkill` binaries that already ship on the target OS.

## Out of scope

The audit also flagged 🔴 **「自动执行路径无审计」** — `autoExecuteShellProposal` / `autoExecutePatchProposal` never call `recordSensitiveActionAudit`. This PR fixes the persistence pipeline; the missing call site should be a separate change so the diff stays focused.

## Test plan

- [x] `cargo check` (Rust 1.85 stable)
- [x] `pnpm test --run` — 457/457
- [x] `pnpm build` (tsc + vite)
- [ ] Manual: cancel a `npm run dev` mid-flight on macOS, confirm `node` child exits within ~1s
- [ ] Manual: launch ~210 background shell jobs, confirm earliest entries fall out of `check_shell_job`
- [ ] Manual: trigger a manual approve, confirm a JSON line lands in `~/.cofree/audit.jsonl`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent on-disk audit logging for sensitive actions with automatic rotation.
  * Frontend now attempts to append audit records to disk when running in the native runtime.
* **Enhancements**
  * Shell job completion tracking now respects configurable capacity and TTL to limit retained entries.
  * Improved process termination for more reliable cleanup of shell jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->